### PR TITLE
Syntax updates  genpdf.sh

### DIFF
--- a/_genpdf.sh
+++ b/_genpdf.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
+# Script creates individual .pdf for each entry of learnxinyminutes.
+
 mkdir _pdfs;
 #pandoc coffeescript.html.markdown -s -o _pdfs/coffeescript.pdf -V geometry:margin=1in --latex-engine=xelatex;
 #exit 1;
 for file in _temp/*.html.markdown
 do
-	base=$(basename "$file");
-	langname=${base//\.html\.markdown/};
-	echo "Making PDF $langname";
-	pandoc "$file" -s -o _pdfs/"$langname".pdf -V geometry:margin=1in --pdf-engine=xelatex
+    base=$(basename "$file");
+    langname=${base//\.html\.markdown/};
+    echo "Making PDF $langname";
+    pandoc "$file" -s -o _pdfs/"$langname".pdf -V geometry:margin=1in --pdf-engine=xelatex
 done
 
 mv _pdfs/c++.pdf _pdfs/cpp.pdf;

--- a/_genpdf.sh
+++ b/_genpdf.sh
@@ -1,12 +1,14 @@
+#!/bin/bash
+
 mkdir _pdfs;
 #pandoc coffeescript.html.markdown -s -o _pdfs/coffeescript.pdf -V geometry:margin=1in --latex-engine=xelatex;
 #exit 1;
 for file in _temp/*.html.markdown
 do
-	base=$(basename $file);
+	base=$(basename "$file");
 	langname=${base//\.html\.markdown/};
 	echo "Making PDF $langname";
-	pandoc $file -s -o _pdfs/$langname.pdf -V geometry:margin=1in --pdf-engine=xelatex
+	pandoc "$file" -s -o _pdfs/"$langname".pdf -V geometry:margin=1in --pdf-engine=xelatex
 done
 
 mv _pdfs/c++.pdf _pdfs/cpp.pdf;

--- a/_genpdf.sh
+++ b/_genpdf.sh
@@ -6,7 +6,7 @@ do
 	base=$(basename $file);
 	langname=${base//\.html\.markdown/};
 	echo "Making PDF $langname";
-	pandoc $file -s -o _pdfs/$langname.pdf -V geometry:margin=1in --latex-engine=xelatex
+	pandoc $file -s -o _pdfs/$langname.pdf -V geometry:margin=1in --pdf-engine=xelatex
 done
 
 mv _pdfs/c++.pdf _pdfs/cpp.pdf;


### PR DESCRIPTION
Contemporary pandoc uses a different keyword to generate .pdf.  This was an incentive to revise the shell script accordingly.  At the same time, suggestions by shellcheck to improve the syntax were considered.